### PR TITLE
fixed text clipping based on screen size

### DIFF
--- a/app/src/main/res/layout/start_screen.xml
+++ b/app/src/main/res/layout/start_screen.xml
@@ -8,8 +8,8 @@
 
     <TextView
         android:id="@+id/textView"
-        android:layout_width="380dp"
-        android:layout_height="812dp"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:layout_gravity="center_vertical"
         android:text="Cosmic Crawlers"
         android:textSize="50sp"


### PR DESCRIPTION
set layout width + height to match_parent for preventing clipping of text